### PR TITLE
Stop NBServerTask properly

### DIFF
--- a/demo/tnonblock_thrift.py
+++ b/demo/tnonblock_thrift.py
@@ -1,0 +1,10 @@
+from sparts.vservice import VService
+from sparts.tasks.thrift import NBServerTask
+from sparts.tasks.fb303 import FB303ProcessorTask
+
+NBServerTask.register()
+FB303ProcessorTask.register()
+
+
+if __name__ == '__main__':
+    VService.initFromCLI()

--- a/sparts/tasks/thrift.py
+++ b/sparts/tasks/thrift.py
@@ -52,8 +52,8 @@ class NBServerTask(VTask):
                          self.name, self.bound_host, self.bound_port)
 
     def stop(self):
-        self.server.close()
         self.server.stop()
+        self.server.close()
         self._stopped = True
 
     def _runloop(self):


### PR DESCRIPTION
TNonblockingServer.close() should be called after
TNonblockingServer.stop()

from TNonblockingServer:

```
    def stop(self):
        """Stop the server.

        This method causes the serve() method to return.  stop() may be invoked
        from within your handler, or from another thread.

        After stop() is called, serve() will return but the server will still
        be listening on the socket.  serve() may then be called again to resume
        processing requests.  Alternatively, close() may be called after
        serve() returns to close the server socket and shutdown all worker
        threads.
        """
```

I didn't see a test for this under test/tasks/ so I added a dumbed down
version of the http_thrift.py demo. Manually tested by launching and
killing the service. Before this change:

```
(venv)08:34:54 (CLD-1282-sparts-prototype)
joeldodge@Joels-MacBook-Air-2.local:~/bronze_python
> python tnonblock_thrift.py --thrift-host 127.0.0.1 --thrift-port 9090
INFO:VService.NBServerTask:NBServerTask Server Started on 127.0.0.1:9090
DEBUG:VService:All tasks started
DEBUG:VService:VService Active.  Awaiting graceful shutdown.
^CINFO:VService:signal -2 received
INFO:VService:Received graceful shutdown request
ERROR:VService.NBServerTask:Unhandled exception in NBServerTask
Traceback (most recent call last):
  File "/Users/joeldodge/bronze_python/venv/lib/python2.7/site-packages/sparts/vtask.py", line 56, in _run
    self._runloop()
  File "/Users/joeldodge/bronze_python/venv/lib/python2.7/site-packages/sparts/tasks/thrift.py", line 61, in _runloop
    self.server.serve()
  File "/Users/joeldodge/bronze_python/venv/lib/python2.7/site-packages/thrift/server/TNonblockingServer.py", line 346, in serve
    self.handle()
  File "/Users/joeldodge/bronze_python/venv/lib/python2.7/site-packages/thrift/server/TNonblockingServer.py", line 306, in handle
    rset, wset, xset = self._select()
  File "/Users/joeldodge/bronze_python/venv/lib/python2.7/site-packages/thrift/server/TNonblockingServer.py", line 298, in _select
    return select.select(readable, writable, readable)
error: (9, 'Bad file descriptor')
INFO:VService:Waiting for tasks to shutdown gracefully...
INFO:VService:Received graceful shutdown request
DEBUG:VService:Waiting for <sparts.tasks.thrift.NBServerTask object at
0x10c693910> to stop...
DEBUG:VService.NBServerTask:Thread NBServerTask exited
DEBUG:VService:Waiting for <sparts.tasks.fb303.FB303ProcessorTask object
at 0x10c693810> to stop...
INFO:VService:Instance shut down gracefully
```

after this change:

```
(venv)08:34:34 (CLD-1282-sparts-prototype)
joeldodge@Joels-MacBook-Air-2.local:~/bronze_python
> python tnonblock_thrift.py --thrift-host 127.0.0.1 --thrift-port 9090
INFO:VService.NBServerTask:NBServerTask Server Started on 127.0.0.1:9090
DEBUG:VService:All tasks started
DEBUG:VService:VService Active.  Awaiting graceful shutdown.
^CINFO:VService:signal -2 received
INFO:VService:Received graceful shutdown request
INFO:VService:Waiting for tasks to shutdown gracefully...
DEBUG:VService:Waiting for <sparts.tasks.thrift.NBServerTask object at
0x100f61910> to stop...
DEBUG:VService.NBServerTask:Thread NBServerTask exited
DEBUG:VService:Waiting for <sparts.tasks.fb303.FB303ProcessorTask object
at 0x100f61810> to stop...
INFO:VService:Instance shut down gracefully
```
