### PR TITLE
Misc base test tweaks

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -1,4 +1,7 @@
-import unittest2
+try:
+    import unittest2
+except ImportError:
+    import unittest as unittest2
 import unittest
 import logging
 
@@ -53,6 +56,11 @@ class ServiceTestCase(BaseSpartsTestCase):
         self.service = TestService(ns)
         self.runloop = self.service.startBG()
 
+    def tearDown(self):
+        self.service.stop()
+        self.runloop.join()
+        super(ServiceTestCase, self).tearDown()
+
 
 class MultiTaskTestCase(ServiceTestCase):
     TASKS = []
@@ -71,10 +79,6 @@ class MultiTaskTestCase(ServiceTestCase):
         super(MultiTaskTestCase, self).setUp()
         for t in self.TASKS:
             self.service.requireTask(t.__name__)
-
-    def tearDown(self):
-        self.service.stop()
-        self.runloop.join()
 
 class SingleTaskTestCase(MultiTaskTestCase):
     TASK = None

--- a/tests/tasks/test_tornado.py
+++ b/tests/tasks/test_tornado.py
@@ -1,3 +1,7 @@
+try:
+    import tornado
+except ImportError:
+    raise AssertionError("Tornado must be installed to run this test")
 from sparts.tasks.tornado import TornadoIOLoopTask, TornadoHTTPTask
 from ..base import MultiTaskTestCase 
 import urllib2

--- a/tests/test_vservice.py
+++ b/tests/test_vservice.py
@@ -1,7 +1,7 @@
 from .base import ServiceTestCase
 
 class VServiceTests(ServiceTestCase):
-    def verifyCustomName(self):
+    def test_verifyCustomName(self):
         self.assertEquals(self.service.name, 'VService')
         self.assertEquals(self.service._name, 'VService')
         self.service.name = 'MyService'


### PR DESCRIPTION
- use python2.7 unittest instead of unittest2?
- need ServiceTestCase subclasses to shutdown too

w/out this the tests never end... (at least using py.test)

ran tests with py.test:

```
Test session starts (darwin, 2.7.5)
plugins: sugar

―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― ERROR collecting externals/sparts/tests/tasks/test_queue_deferred.py ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
externals/sparts/tests/tasks/test_queue_deferred.py:8: in <module>
>       raise AssertionError("Twisted must be installed to run this test")
E       AssertionError: Twisted must be installed to run this test

――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― ERROR collecting externals/sparts/tests/tasks/test_tornado.py ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――
externals/sparts/tests/tasks/test_tornado.py:1: in <module>
>   from sparts.tasks.tornado import TornadoIOLoopTask, TornadoHTTPTask
venv/lib/python2.7/site-packages/sparts/tasks/tornado.py:6: in <module>
>   import tornado.ioloop
E   ImportError: No module named tornado.ioloop

   externals/sparts/tests/test_vservice.py ✓                                                                                                                                                                                                                                                               11% ██████████
   externals/sparts/tests/tasks/test_file.py ✓✓✓                                                                                                                                                                                                                                                           38% ██████████
   externals/sparts/tests/tasks/test_periodic.py ✓✓                                                                                                                                                                                                                                                        63% ██████████
   externals/sparts/tests/tasks/test_poller.py ✓                                                                                                                                                                                                                                                           75% ██████████
   externals/sparts/tests/tasks/test_queue.py ✓✓                                                                                                                                                                                                                                                          100% ██████████

Results (5.54s):
   8 passed
```
