### PR TITLE
dbus: multithreading fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -132,7 +132,7 @@ class NoDirtyUpload(UploadCommand):
             # New files are ok for now.
             if stat == '??':
                 continue
-            
+
             raise AssertionError("Unexpected git status (%s) for %s" %
                 (stat, fn))
 

--- a/sparts/tasks/dbus.py
+++ b/sparts/tasks/dbus.py
@@ -24,6 +24,11 @@ import gobject
 import glib
 import time
 
+# always init threads before calling any dbus code
+glib.threads_init()
+gobject.threads_init()
+dbus.mainloop.glib.threads_init()
+
 
 class VServiceDBusObject(dbus.service.Object):
     """DBus interface implementation that exports common VService methods"""
@@ -99,9 +104,6 @@ class DBusMainLoopTask(VTask):
             raise SkipTask("No DBusTasks found or enabled")
 
         self.dbus_loop = DBusGMainLoop(set_as_default=True)
-        glib.threads_init()
-        gobject.threads_init()
-        dbus.mainloop.glib.threads_init()
         self.mainloop = gobject.MainLoop()
 
     def _runloop(self):

--- a/sparts/tasks/dbus.py
+++ b/sparts/tasks/dbus.py
@@ -26,11 +26,6 @@ import gobject
 import glib
 import time
 
-# always init threads before calling any dbus code
-glib.threads_init()
-gobject.threads_init()
-dbus.mainloop.glib.threads_init()
-
 
 class VServiceDBusObject(dbus.service.Object):
     """DBus interface implementation that exports common VService methods"""
@@ -109,6 +104,11 @@ class DBusMainLoopTask(VTask):
 
         if not needed:
             raise SkipTask("No DBusTasks found or enabled")
+
+        # always init threads before calling any dbus code
+        glib.threads_init()
+        gobject.threads_init()
+        dbus.mainloop.glib.threads_init()
 
         self.dbus_loop = DBusGMainLoop(set_as_default=True)
         # using main loop with default context

--- a/sparts/tasks/dbus.py
+++ b/sparts/tasks/dbus.py
@@ -231,13 +231,13 @@ class DBusServiceTask(DBusTask):
 
     def _asyncStopCb(self):
         self.dbus_service = None
+        # self.bus.close()
         self.bus = None
         return True
 
     def _asyncStop(self):
         res = self.asyncRun(self._asyncStopCb)
         res.result()
-        # self.bus.close()
 
     def stop(self):
         """Run the bus cleanup code within the context of the main loop. The

--- a/tests/tasks/test_dbus.py
+++ b/tests/tasks/test_dbus.py
@@ -6,36 +6,44 @@
 #
 from sparts.tests.base import MultiTaskTestCase, Skip
 try:
-    import dbus
     from sparts.tasks.dbus import DBusServiceTask, DBusMainLoopTask
+    import dbus
 except ImportError:
     raise Skip("dbus support is required to run this test")
 
 from sparts.sparts import option
 from random import getrandbits
+import time
 
-
-class TestDBusTask(DBusServiceTask):
-    BUS_NAME = 'com.github.facebook.test-{}'.format(getrandbits(32))
-
-
-class TestDBusSystemTask(DBusServiceTask):
-    BUS_NAME = 'com.github.facebook.systemtest'
-    USE_SYSTEM_BUS = True
-
+class BaseTestDBusTask(DBusServiceTask):
     def start(self):
         try:
-            super(TestDBusSystemTask, self).start()
+            self.logger.debug('call start()')
+            super(BaseTestDBusTask, self).start()
         except dbus.DBusException as err:
+            self.logger.debug('got exception')
             self.acquire_name_error = str(err)
 
 
+class TestDBusSessionTask(BaseTestDBusTask):
+    OPT_PREFIX = 'dbus-session'
+    BUS_NAME = 'com.github.facebook.test-{}'.format(getrandbits(32))
+
+
+class TestDBusSystemTask(BaseTestDBusTask):
+    OPT_PREFIX = 'dbus-system'
+    BUS_NAME = 'com.github.facebook.systemtest'
+    USE_SYSTEM_BUS = True
+
+
 class TestDBus(MultiTaskTestCase):
-    TASKS = [TestDBusTask, DBusMainLoopTask]
+    TASKS = [TestDBusSessionTask, DBusMainLoopTask]
 
     def test_session_bus(self):
-        bus = dbus.SessionBus(private=True)
-        self.assertTrue(bus.name_has_owner(TestDBusTask.BUS_NAME))
+        # expecting session task to have been started without error
+        t = self.service.getTask(TestDBusSessionTask)
+        err = getattr(t, 'acquire_name_error', None)
+        self.assertEqual(err, None)
 
 
 class TestSystemDBus(MultiTaskTestCase):
@@ -46,5 +54,5 @@ class TestSystemDBus(MultiTaskTestCase):
         t = self.service.getTask(TestDBusSystemTask)
         err = getattr(t, 'acquire_name_error', None)
         self.assertNotNone(err)
-
+        self.logger.debug('err: %s', err)
         self.assertTrue(err.startswith('org.freedesktop.DBus.Error.AccessDenied'))


### PR DESCRIPTION
The patchset fixes a number of multithreading issues with current dbus handling in sparts.tasks.dbus module. The man issue is that dbus-python bindings are not really thread safe, but DBusMainLoopTask and DBusServiceTask are effectively run in separate threads (i.e. main loop task is started within a thread, but the DBusServiceTask methods are called from the main thread when starting up).

In typical applications the usage pattern is as follows:
1. import dbus
2. enable threading
3. setup bus/proxies & own names
4. run main loop

In sparts the sequence is like this:
1. import dbus
2. enable threading
3. start main loop
4. setup dbus proxies/own names etc

The problem was noticed only after merging pull request https://github.com/facebook/sparts/pull/97 as a couple of test cases was added. The stress tests can be run like this:
`while nosetests tests.tasks.test_dbus -sv --logging-level=DEBUG --nologcapture; do ; done`

With current master, running this will either fail, segfault, abort (glibc reporting double free()) or just block when quitting.

The patchset resolves these problems by moving dbus related calls to the thread running the main loop. Setup calls (i.e. task's `start()` and `stop()` mthods) are run through a helper method `DBusTask.asyncRun()`, that can also be used to run arbitrary callback within the main loop's context. The helper code schedules and idle callback within the loop using a thread-safe `glib.idle_add()`.


