### PR TITLE
manifest: add manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include PATENTS


### PR DESCRIPTION
Adding MANIFEST so that both LICENSE and PATENTS will be picked up for
source dist. Although not required this is generally useful when
packaging for Linux distributions. For instance, the packaging for
OpenEmbedded that I submitted just recently [1] needed to fallback to
pulling sources from github in order to access the LICENSE
file. While, should the file be included in sdist a very simple PyPI
handler would be enough, like for instance with python-daemonize [2].

[1] http://article.gmane.org/gmane.comp.handhelds.openembedded/69731
[2] http://article.gmane.org/gmane.comp.handhelds.openembedded/69729