### PR TITLE
QueuTask: prevent unhandled exception from tearing the main loop down

### DIFF
--- a/sparts/vtask.py
+++ b/sparts/vtask.py
@@ -202,6 +202,13 @@ class ExecuteContext(object):
         if self.future is not None:
             self.future.set_exception(exception)
 
+            # For future-based work, let's allow the submitter to handle the
+            # exception gracefully. Since we can't know if that was successful,
+            # just assume the exception will be handled (or re-raised) by
+            # someone awaiting the future.
+            # This isn't guaranteed, but is a reasonable assumption.
+            handled = True
+
         if self.deferred is not None:
             unhandled = []
             self.deferred.addErrback(self._unhandledErrback, unhandled)

--- a/tests/tasks/test_queue_futures.py
+++ b/tests/tasks/test_queue_futures.py
@@ -128,3 +128,19 @@ class FutureTests(SingleTaskTestCase):
         # Wait for it to complete, check the result
         result = ctx.future.result(5.0)
         self.assertEqual(result, 'foobar')
+
+    def test_future_runloop_raises(self):
+        """Unhandled exception does not kill the whole loop."""
+        self.task.do_raise = True
+
+        fut = self.task.submit('not-an-actual-task')
+
+        # This should not raise an exception even if - wait for the main thread
+        # for half a second
+        self.runloop.join(0.5)
+
+        # The main thread should still be alive...
+        self.assertTrue(self.runloop.isAlive())
+
+        # The future should have an exception set on it
+        self.assertTrue(fut.exception())


### PR DESCRIPTION
Prior to this patch - raising an exception inside an execute() of a
queued
task when using futures instead of deferreds, would tear down the whole
service thread. This is almost certainly not what we want.

The cleanest way to fix this seems to be in the ExecutionContext, where
we consider an exception handled if it's set on a future, and let the
submitter worry about it.